### PR TITLE
Extract common options to cucumber.js

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,29 +13,16 @@
       "stopOnEntry": false,
       "program": "${workspaceRoot}/node_modules/@cucumber/cucumber/bin/cucumber-js",
       "args": [
-        "features/**/*.feature",
-        "--require",
-        "env/set-environment-variables.ts",
-        "--require",
-        "world/custom-world.ts",
-        "--require", 
-        "step-definitions/**/*.ts",
-        "--require",
-        "hooks/**/*.ts",
-        "--require-module",
-        "ts-node/register",
-        "--format-options" ,
-        "{\"snippetInterface\": \"async-await\"}",
         "--format",
         "summary",
         "--tags",
         "@debug",
-        "--publish-quiet"
       ],
       "cwd": "${workspaceRoot}",
       "runtimeArgs": [
-        "--nolazy"],
-    "sourceMaps": true
+        "--nolazy"
+      ],
+      "sourceMaps": true
     }
   ]
 }

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,0 +1,4 @@
+module.exports = {
+  default:
+    'features/**/*.feature --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \'{"snippetInterface": "async-await"}\' --publish-quiet',
+};

--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf build && npm run format && npm run lint && tsc && npm run cucumber-check",
-    "cucumber-check": "node ./node_modules/@cucumber/cucumber/bin/cucumber-js features/**/*.feature --dry-run --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format summary --format progress --format progress-bar  --publish-quiet",
-    "cucumber": "node ./node_modules/@cucumber/cucumber/bin/cucumber-js features/**/*.feature --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\"  --format html:reports/report.html --format summary --format @cucumber/pretty-formatter --format cucumber-console-formatter --publish-quiet",
+    "cucumber-check": "npx cucumber-js --dry-run --format summary --format progress --format progress-bar",
+    "cucumber": "npx cucumber-js --format html:reports/report.html --format summary --format @cucumber/pretty-formatter --format cucumber-console-formatter",
     "eslint-fix": "eslint ./ --ext .js,.ts,.tsx --fix",
     "eslint-init": "eslint --init",
     "format": "prettier --write \"**/*.{ts,tsx,css,html}\" ",
     "lint": "eslint ./ --ext .js,.ts,.tsx --format visualstudio --no-color --max-warnings 10 --report-unused-disable-directives",
     "only": "npm run cucumber -- --tags @only",
     "report": "open reports/report.html",
-    "snippets": "node ./node_modules/@cucumber/cucumber/bin/cucumber-js features/**/*.feature --dry-run --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format snippets  --publish-quiet",
-    "steps-usage": "node ./node_modules/@cucumber/cucumber/bin/cucumber-js features/**/*.feature --dry-run --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format usage  --publish-quiet",
+    "snippets": "npx cucumber-js --dry-run --format snippets",
+    "steps-usage": "npx cucumber-js --dry-run --format usage",
     "test": "npm run cucumber"
   },
   "engines": {


### PR DESCRIPTION
First of all, thanks for creating great starter template!

Extract common duplicated options in `package.json` and `.vscode/launch.json`

I'm not sure this is good idea or not. but.. This patch will address https://github.com/hdorgeval/cucumber7-ts-starter/issues/2
